### PR TITLE
Add support for http://www.opengis.net/def/crs/EPSG/0/25832 as CRS

### DIFF
--- a/map-viewer/src/components/MapViewer.js
+++ b/map-viewer/src/components/MapViewer.js
@@ -20,6 +20,8 @@ import proj4 from 'proj4';
 
 // Define and register the projection for EPSG:25832
 proj4.defs('EPSG:25832', '+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs +axis=enu');
+// Define the http URI form of EPSG:25832 as named alias
+proj4.defs('http://www.opengis.net/def/crs/EPSG/0/25832', proj4.defs('EPSG:25832'));
 register(proj4);
 
 // Get the EPSG:25832 projection


### PR DESCRIPTION
See also http://proj4js.org/#named-projections and https://docs.ogc.org/pol/09-048r5.html#_names_for_epsg_definitions.

This allows for using geometries such as:

```xml
<gml:Surface srsName="http://www.opengis.net/def/crs/EPSG/0/25832" srsDimension="2">
  <!-- ... -->
</gml:Surface
```